### PR TITLE
記事詳細ページのタイトルサイズを縮小して改行を削減

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
       {/* 記事ヘッダー */}
       <article className="max-w-3xl mx-auto">
         <header className="mb-8">
-          <h1 className="text-4xl font-bold mb-4 leading-tight">{post.title}</h1>
+          <h1 className="text-2xl md:text-3xl font-bold mb-4 leading-tight">{post.title}</h1>
 
           <div className="flex items-center gap-4 text-sm text-gray-600">
             <time>{formattedDate}</time>


### PR DESCRIPTION
- スマホ: text-4xl → text-2xl (24px)
- PC: text-4xl → text-3xl (30px)
- 改行が少なくなり読みやすさが向上