### PR TITLE
Vercel Web Analyticsを設定してアクセス数を追跡可能に

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { WebsiteJsonLd } from "@/components/JsonLd";
+import { Analytics } from "@vercel/analytics/next";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://nexeed-blog.vercel.app"),
@@ -73,6 +74,7 @@ export default function RootLayout({
           </main>
           <Footer />
         </div>
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.5.19",
+        "@vercel/analytics": "^1.6.1",
         "date-fns": "^4.1.0",
         "gray-matter": "^4.0.3",
         "next": "^15.1.6",
@@ -1656,6 +1657,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
+    "@vercel/analytics": "^1.6.1",
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",
     "next": "^15.1.6",


### PR DESCRIPTION
@vercel/analyticsパッケージを追加し、アプリケーションのルートレイアウトにAnalyticsコンポーネントを統合しました。これにより、blog.nexeed-web.comのページビューとアクセス数をVercelダッシュボードで確認できるようになります。

変更内容：
- @vercel/analyticsパッケージをインストール
- app/layout.tsxにAnalyticsコンポーネントを追加
- ビルドテストで問題ないことを確認