### PR TITLE
aboutページとヘッダーに画像を追加

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import Image from "next/image";
 
 export const metadata: Metadata = {
   title: "About | NEXEED BLOG",
@@ -12,12 +13,16 @@ export default function AboutPage() {
         <h1 className="text-4xl font-bold mb-8">About</h1>
 
         <div className="bg-white rounded-lg shadow-sm p-8">
-          {/* プロフィール画像（イニシャルアイコン） */}
+          {/* プロフィール画像 */}
           <div className="flex flex-col md:flex-row gap-8 mb-8">
             <div className="flex-shrink-0">
-              <div className="w-32 h-32 rounded-full bg-primary text-white flex items-center justify-center text-4xl font-bold">
-                ON
-              </div>
+              <Image
+                src="/2E725D0E-E0E7-49D1-AF18-87FC132B7612.jpeg"
+                alt="大島直孝のプロフィール写真"
+                width={128}
+                height={128}
+                className="rounded-full object-cover"
+              />
             </div>
 
             <div className="flex-1">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import SearchBox from "./SearchBox";
 import { useState } from "react";
 
@@ -17,8 +18,15 @@ export default function Header() {
     <header className="bg-white shadow-sm sticky top-0 z-50">
       <div className="container-custom">
         <div className="flex items-center justify-between h-16">
-          <Link href="/" className="text-xl md:text-2xl font-bold text-gray-900 hover:text-primary">
-            NEXEED BLOG
+          <Link href="/" className="flex items-center hover:opacity-80 transition-opacity">
+            <Image
+              src="/8B126C29-1D4C-433F-955C-207F639A33F1.jpeg"
+              alt="NEXEED BLOG"
+              width={180}
+              height={50}
+              className="h-8 md:h-10 w-auto"
+              priority
+            />
           </Link>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
- aboutページのプロフィール画像を追加（イニシャルアイコンから実際の写真に変更）
- ヘッダーのテキストロゴを画像ロゴに置き換え