### PR TITLE
特定の記事に特定のアフィリエイトバナーを指定できる機能を追加

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { BlogPostJsonLd } from "@/components/JsonLd";
 import Link from "next/link";
 import A8Banner from "@/components/A8Banner";
 import MoshimoBanner from "@/components/MoshimoBanner";
-import { getResponsiveBanners, getResponsiveMoshimoBanners } from "@/data/affiliate-links";
+import { getResponsiveBanners, getResponsiveMoshimoBanners, getBannerPairById } from "@/data/affiliate-links";
 
 export async function generateStaticParams() {
   const posts = getAllPosts();
@@ -81,14 +81,28 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   const tocItems = extractTocFromHtml(post.content || "");
 
   // カテゴリーとslugに応じたアフィリエイトバナー（PC/モバイル対応）を取得
-  // slugベースで決定的にバナーを選択するため、同じ記事では常に同じバナーが表示される
-  // もしもアフィリエイトを優先的に使用し、なければA8.netを使用
-  const moshimoBannerPair = getResponsiveMoshimoBanners(post.category, slug);
-  const a8BannerPair = getResponsiveBanners(post.category, slug);
+  // affiliateBannerIdが指定されている場合は、それを優先的に使用
+  // それ以外の場合は、カテゴリーとslugベースで決定的にバナーを選択
+  let bannerPair;
+  let bannerType: 'moshimo' | 'a8' = 'a8';
 
-  // バナーの種類を判定
-  const bannerType = moshimoBannerPair ? 'moshimo' : 'a8';
-  const bannerPair = moshimoBannerPair || a8BannerPair;
+  if (post.affiliateBannerId) {
+    // 特定のバナーが指定されている場合
+    const customBanner = getBannerPairById(post.affiliateBannerId);
+    if (customBanner) {
+      bannerPair = customBanner;
+      // バナーの種類を判定（trackingSrcの有無で判断）
+      bannerType = 'trackingSrc' in customBanner.desktop ? 'moshimo' : 'a8';
+    }
+  }
+
+  // カスタムバナーが見つからない場合は、カテゴリーベースで選択
+  if (!bannerPair) {
+    const moshimoBannerPair = getResponsiveMoshimoBanners(post.category, slug);
+    const a8BannerPair = getResponsiveBanners(post.category, slug);
+    bannerType = moshimoBannerPair ? 'moshimo' : 'a8';
+    bannerPair = moshimoBannerPair || a8BannerPair;
+  }
 
   return (
     <>

--- a/data/affiliate-links.ts
+++ b/data/affiliate-links.ts
@@ -1791,3 +1791,52 @@ export function getResponsiveMoshimoBanners(category: string, slug?: string): Mo
   // slugがない場合は最初のサービスを返す
   return validServices[0];
 }
+
+// バナーIDで特定のバナーペアを取得
+export function getBannerPairById(bannerId: string): BannerPair | MoshimoBannerPair | undefined {
+  // A8リンクから検索
+  const a8Link = a8Links.find(link => link.id === bannerId);
+  if (a8Link) {
+    // 同じnameを持つバナーを探す
+    const sameNameBanners = a8Links.filter(link => link.name === a8Link.name);
+    const desktopBanner = sameNameBanners.find(b => isDesktopSize(b.width, b.height));
+    const mobileBanner = sameNameBanners.find(b => isMobileSize(b.width, b.height));
+    
+    if (desktopBanner && mobileBanner) {
+      return {
+        desktop: desktopBanner,
+        mobile: mobileBanner,
+      };
+    }
+    
+    // ペアが見つからない場合は同じバナーを返す
+    return {
+      desktop: a8Link,
+      mobile: a8Link,
+    };
+  }
+  
+  // もしもアフィリエイトリンクから検索
+  const moshimoLink = moshimoLinks.find(link => link.id === bannerId);
+  if (moshimoLink) {
+    // 同じnameを持つバナーを探す
+    const sameNameBanners = moshimoLinks.filter(link => link.name === moshimoLink.name);
+    const desktopBanner = sameNameBanners.find(b => isDesktopSize(b.width, b.height));
+    const mobileBanner = sameNameBanners.find(b => isMobileSize(b.width, b.height));
+    
+    if (desktopBanner && mobileBanner) {
+      return {
+        desktop: desktopBanner,
+        mobile: mobileBanner,
+      };
+    }
+    
+    // ペアが見つからない場合は同じバナーを返す
+    return {
+      desktop: moshimoLink,
+      mobile: moshimoLink,
+    };
+  }
+  
+  return undefined;
+}

--- a/docs/AFFILIATE_USAGE.md
+++ b/docs/AFFILIATE_USAGE.md
@@ -381,3 +381,93 @@ const sideBusinessLinks = [
 
 **作成日**: 2026-01-08
 **最終更新**: 2026-01-08
+
+## 🎯 特定の記事に特定のバナーを挿入する方法
+
+記事のfrontmatterに`affiliateBannerId`を追加することで、その記事専用のアフィリエイトバナーを指定できます。
+
+### 使い方
+
+記事のMarkdownファイルのfrontmatterに`affiliateBannerId`を追加します：
+
+```markdown
+---
+title: "記事タイトル"
+date: "2026-01-13"
+category: "ITエンジニア"
+excerpt: "記事の説明"
+affiliateBannerId: "techmeets-programming"
+---
+```
+
+### 利用可能なバナーID（カテゴリー別）
+
+#### ITエンジニア向け
+
+**プログラミングスクール**:
+- `techmeets-programming` - テックミーツ（プログラミング講座）
+- `dmmwebcamp-career-*` - DMM WEBCAMP（転職コース）
+- `dmmwebcamp-skills-*` - DMM WEBCAMP（学習コース）
+- `datasciencebootcamp-*` - データサイエンスブートキャンプ
+- `digitalholywood-*` - デジタルハリウッド
+
+**サーバー・ホスティング**:
+- `lolipop-rental-server-*` - ロリポップ！レンタルサーバー
+- `xserver-rental-*` - エックスサーバー
+
+**就労支援**:
+- `revive-*` - リバイブ（就労支援B型）
+
+#### 副業向け
+
+**クラウドソーシング**:
+- `lancers-*` - ランサーズ
+- `crowdworks-*` - クラウドワークス
+- `coconala-*` - ココナラ
+
+**スキルマーケット**:
+- `skillots-*` - スキロッツ
+
+#### 子育て向け
+
+**プログラミング教育**:
+- `kidsrobo-*` - キッズロボ（子ども向けプログラミング）
+
+**育児サポート**:
+- `baby-planet-*` - ベビープラネット
+
+**教育サービス**:
+- `at-seminar-*` - ATセミナー
+
+#### 投資向け
+
+**証券会社**:
+- `fpo-stocks-*` - FPO証券（株式）
+- `fpo-fx-guide-*` - FPO（FX）
+
+**投資セミナー**:
+- `financial-academy-*` - ファイナンシャルアカデミー
+
+### 注意事項
+
+1. **バナーIDはペアで機能**: 同じサービス名（例: `techmeets`）でPC用とモバイル用のバナーが自動的にペアリングされます
+2. **存在しないIDを指定した場合**: カテゴリーベースの自動選択にフォールバックします
+3. **カテゴリーとの整合性**: バナーIDを指定しても、記事のカテゴリーは正しく設定してください
+
+### 使用例
+
+```markdown
+---
+title: "Dify：ノーコードでAIアプリケーションを構築"
+date: "2026-01-13"
+category: "ITエンジニア"
+excerpt: "Difyの詳しい解説"
+affiliateBannerId: "dmmwebcamp-skills-300x250-1"
+---
+```
+
+この設定により、Dify記事にはDMM WEBCAMPのバナーが優先的に表示されます。
+
+---
+
+**最終更新**: 2026-01-15

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -17,6 +17,7 @@ export interface PostData {
   coverImage?: string;
   updated?: string;
   content?: string;
+  affiliateBannerId?: string; // 特定のアフィリエイトバナーを指定
 }
 
 export function getAllPosts(): PostData[] {
@@ -42,6 +43,7 @@ export function getAllPosts(): PostData[] {
         excerpt: data.excerpt,
         coverImage: data.coverImage,
         updated: data.updated,
+        affiliateBannerId: data.affiliateBannerId,
       } as PostData;
     });
 
@@ -82,6 +84,7 @@ export async function getPostBySlug(slug: string): Promise<PostData> {
     coverImage: data.coverImage,
     updated: data.updated,
     content: contentHtml,
+    affiliateBannerId: data.affiliateBannerId,
   };
 }
 


### PR DESCRIPTION
記事のfrontmatterに`affiliateBannerId`を追加することで、
その記事専用のアフィリエイトバナーを指定できるようになりました。

主な変更:
- PostData型にaffiliateBannerIdフィールドを追加
- getBannerPairById関数を追加（バナーIDで検索）
- バナー選択ロジックを更新（frontmatterの指定を最優先）
- AFFILIATE_USAGE.mdに使用方法とバナーID一覧を追加

使用例:
---
title: "記事タイトル"
category: "ITエンジニア"
affiliateBannerId: "techmeets-programming"
---

指定されたバナーIDが見つからない場合は、
従来のカテゴリーベース自動選択にフォールバックします。