### PR TITLE
カテゴリごとの見出しデザインを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,4 +32,56 @@
   .btn-primary {
     @apply bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark transition-colors;
   }
+
+  /* カテゴリごとの見出しスタイル - 投資 */
+  .post-category-investment .prose h2 {
+    @apply bg-blue-50 border-l-4 border-blue-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
+  }
+
+  .post-category-investment .prose h3 {
+    @apply bg-blue-50 border-l-4 border-blue-400 pl-4 py-2 rounded-r-md mb-4 mt-6;
+  }
+
+  .post-category-investment .prose h4 {
+    @apply bg-blue-50 border-l-4 border-blue-300 pl-4 py-2 rounded-r-md mb-3 mt-4;
+  }
+
+  /* カテゴリごとの見出しスタイル - 子育て */
+  .post-category-parenting .prose h2 {
+    @apply bg-pink-50 border-l-4 border-pink-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
+  }
+
+  .post-category-parenting .prose h3 {
+    @apply bg-pink-50 border-l-4 border-pink-400 pl-4 py-2 rounded-r-md mb-4 mt-6;
+  }
+
+  .post-category-parenting .prose h4 {
+    @apply bg-pink-50 border-l-4 border-pink-300 pl-4 py-2 rounded-r-md mb-3 mt-4;
+  }
+
+  /* カテゴリごとの見出しスタイル - ITエンジニア */
+  .post-category-engineering .prose h2 {
+    @apply bg-green-50 border-l-4 border-green-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
+  }
+
+  .post-category-engineering .prose h3 {
+    @apply bg-green-50 border-l-4 border-green-400 pl-4 py-2 rounded-r-md mb-4 mt-6;
+  }
+
+  .post-category-engineering .prose h4 {
+    @apply bg-green-50 border-l-4 border-green-300 pl-4 py-2 rounded-r-md mb-3 mt-4;
+  }
+
+  /* カテゴリごとの見出しスタイル - 副業 */
+  .post-category-side-business .prose h2 {
+    @apply bg-purple-50 border-l-4 border-purple-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
+  }
+
+  .post-category-side-business .prose h3 {
+    @apply bg-purple-50 border-l-4 border-purple-400 pl-4 py-2 rounded-r-md mb-4 mt-6;
+  }
+
+  .post-category-side-business .prose h4 {
+    @apply bg-purple-50 border-l-4 border-purple-300 pl-4 py-2 rounded-r-md mb-3 mt-4;
+  }
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -70,6 +70,13 @@ const categoryColors: Record<string, string> = {
   "副業": "bg-purple-100 text-purple-800",
 };
 
+const categoryClasses: Record<string, string> = {
+  "投資": "post-category-investment",
+  "子育て": "post-category-parenting",
+  "ITエンジニア": "post-category-engineering",
+  "副業": "post-category-side-business",
+};
+
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await getPostBySlug(slug);
@@ -149,13 +156,14 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         {/* 記事本文（バナーを複数箇所に自動挿入） */}
         {(() => {
           const content = post.content || "";
+          const categoryClass = categoryClasses[post.category] || "";
 
           if (!bannerPair) {
             // バナーがない場合は通常表示
             return (
               <>
                 <div
-                  className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
+                  className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
                   dangerouslySetInnerHTML={{ __html: content }}
                 />
               </>
@@ -195,7 +203,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
             segments.push(
               <div
                 key={`content-${i}`}
-                className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
+                className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
                 dangerouslySetInnerHTML={{ __html: segmentContent }}
               />
             );
@@ -231,7 +239,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           segments.push(
             <div
               key={`content-last`}
-              className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
+              className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
               dangerouslySetInnerHTML={{ __html: lastSegment }}
             />
           );


### PR DESCRIPTION
- 記事の見出し（h2, h3, h4）に背景色と左ボーダーを追加
- カテゴリごとに異なる色を適用（投資=青、子育て=ピンク、ITエンジニア=緑、副業=紫）
- 見出しの視認性とデザイン性を向上
- globals.cssにカテゴリごとのスタイルを追加
- 記事ページテンプレートにカテゴリクラスを適用