### PR TITLE
記事タイトルと目次にカテゴリごとの背景デザインを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -34,6 +34,14 @@
   }
 
   /* カテゴリごとの見出しスタイル - 投資 */
+  .post-category-investment .post-title {
+    @apply bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-4 shadow-md;
+  }
+
+  .post-category-investment .post-toc {
+    @apply bg-blue-50 border border-blue-200 shadow-sm;
+  }
+
   .post-category-investment .prose h2 {
     @apply bg-blue-50 border-l-4 border-blue-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
   }
@@ -47,6 +55,14 @@
   }
 
   /* カテゴリごとの見出しスタイル - 子育て */
+  .post-category-parenting .post-title {
+    @apply bg-gradient-to-r from-pink-500 to-pink-600 text-white px-6 py-4 shadow-md;
+  }
+
+  .post-category-parenting .post-toc {
+    @apply bg-pink-50 border border-pink-200 shadow-sm;
+  }
+
   .post-category-parenting .prose h2 {
     @apply bg-pink-50 border-l-4 border-pink-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
   }
@@ -60,6 +76,14 @@
   }
 
   /* カテゴリごとの見出しスタイル - ITエンジニア */
+  .post-category-engineering .post-title {
+    @apply bg-gradient-to-r from-green-500 to-green-600 text-white px-6 py-4 shadow-md;
+  }
+
+  .post-category-engineering .post-toc {
+    @apply bg-green-50 border border-green-200 shadow-sm;
+  }
+
   .post-category-engineering .prose h2 {
     @apply bg-green-50 border-l-4 border-green-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
   }
@@ -73,6 +97,14 @@
   }
 
   /* カテゴリごとの見出しスタイル - 副業 */
+  .post-category-side-business .post-title {
+    @apply bg-gradient-to-r from-purple-500 to-purple-600 text-white px-6 py-4 shadow-md;
+  }
+
+  .post-category-side-business .post-toc {
+    @apply bg-purple-50 border border-purple-200 shadow-sm;
+  }
+
   .post-category-side-business .prose h2 {
     @apply bg-purple-50 border-l-4 border-purple-500 pl-4 py-3 rounded-r-md mb-6 mt-8;
   }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -83,6 +83,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
   const relatedPosts = getRelatedPosts(slug, post.category, 3);
 
   const formattedDate = format(new Date(post.date), "yyyy年M月d日", { locale: ja });
+  const categoryClass = categoryClasses[post.category] || "";
 
   // 目次を抽出
   const tocItems = extractTocFromHtml(post.content || "");
@@ -131,9 +132,9 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
       </nav>
 
       {/* 記事ヘッダー */}
-      <article className="max-w-3xl mx-auto">
+      <article className={`max-w-3xl mx-auto ${categoryClass}`}>
         <header className="mb-8">
-          <h1 className="text-xl md:text-2xl font-bold mb-4 leading-tight">{post.title}</h1>
+          <h1 className="post-title text-xl md:text-2xl font-bold mb-4 leading-tight">{post.title}</h1>
 
           <div className="flex items-center gap-4 text-sm text-gray-600">
             <time>{formattedDate}</time>
@@ -148,7 +149,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
 
         {/* 目次 */}
         {tocItems.length > 0 && (
-          <div className="mb-8">
+          <div className="post-toc mb-8 p-4">
             <TableOfContents items={tocItems} />
           </div>
         )}
@@ -156,7 +157,6 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         {/* 記事本文（バナーを複数箇所に自動挿入） */}
         {(() => {
           const content = post.content || "";
-          const categoryClass = categoryClasses[post.category] || "";
 
           if (!bannerPair) {
             // バナーがない場合は通常表示


### PR DESCRIPTION
- 記事タイトルにカテゴリごとのグラデーション背景を追加
- タイトルは白文字でカードタイプのデザイン（シャドウあり）
- 目次にもカテゴリごとの背景色とボーダーを追加
- カテゴリごとの配色（投資=青、子育て=ピンク、ITエンジニア=緑、副業=紫）
- 視認性とデザイン性を大幅に向上