### PR TITLE
カテゴリベースのデザイン改善を実装

### DIFF
--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -11,6 +11,20 @@ const categories: Record<string, string> = {
   "side-business": "副業",
 };
 
+const categoryColors: Record<string, string> = {
+  "investment": "bg-blue-500 text-white border-blue-600",
+  "parenting": "bg-pink-500 text-white border-pink-600",
+  "engineering": "bg-green-500 text-white border-green-600",
+  "side-business": "bg-purple-500 text-white border-purple-600",
+};
+
+const categoryHeaderColors: Record<string, string> = {
+  "investment": "bg-gradient-to-r from-blue-500 to-blue-600 text-white",
+  "parenting": "bg-gradient-to-r from-pink-500 to-pink-600 text-white",
+  "engineering": "bg-gradient-to-r from-green-500 to-green-600 text-white",
+  "side-business": "bg-gradient-to-r from-purple-500 to-purple-600 text-white",
+};
+
 export async function generateStaticParams() {
   return Object.keys(categories).map((slug) => ({
     slug,
@@ -63,6 +77,9 @@ export default async function CategoryPage({ params }: { params: Promise<{ slug:
   const totalPages = getTotalPages(allPosts.length, POSTS_PER_PAGE);
   const posts = getPaginatedPosts(allPosts, 1, POSTS_PER_PAGE);
 
+  const headerColor = categoryHeaderColors[slug] || "bg-gray-700 text-white";
+  const categoryColor = categoryColors[slug] || "bg-gray-100 text-gray-800 border-gray-300";
+
   return (
     <div className="container-custom py-12">
       {/* パンくずリスト */}
@@ -71,10 +88,10 @@ export default async function CategoryPage({ params }: { params: Promise<{ slug:
         <span className="mx-2">/</span>
         <span>カテゴリー</span>
         <span className="mx-2">/</span>
-        <span className="text-gray-900 font-medium">{categoryName}</span>
+        <span className={`px-3 py-1 rounded-md font-bold border-2 shadow-sm ${categoryColor}`}>{categoryName}</span>
       </nav>
 
-      <h1 className="text-4xl font-bold mb-8">{categoryName}の記事</h1>
+      <h1 className={`text-2xl md:text-3xl font-bold mb-8 px-6 py-4 shadow-md ${headerColor}`}>{categoryName}の記事</h1>
 
       {posts.length > 0 ? (
         <>

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,6 +33,23 @@
     @apply bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark transition-colors;
   }
 
+  /* カテゴリボタンのスタイル */
+  .category-btn-investment {
+    @apply border-blue-300 hover:border-blue-500 hover:bg-blue-50;
+  }
+
+  .category-btn-parenting {
+    @apply border-pink-300 hover:border-pink-500 hover:bg-pink-50;
+  }
+
+  .category-btn-engineering {
+    @apply border-green-300 hover:border-green-500 hover:bg-green-50;
+  }
+
+  .category-btn-side-business {
+    @apply border-purple-300 hover:border-purple-500 hover:bg-purple-50;
+  }
+
   /* カテゴリごとの見出しスタイル - 投資 */
   .post-category-investment .post-title {
     @apply bg-gradient-to-r from-blue-500 to-blue-600 text-white px-6 py-4 shadow-md;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,10 @@ import { getPaginatedPosts, getTotalPages, POSTS_PER_PAGE } from "@/lib/paginati
 import Link from "next/link";
 
 const categories = [
-  { slug: "investment", name: "投資", icon: "💰", description: "資産形成・インデックス投資" },
-  { slug: "engineering", name: "ITエンジニア", icon: "💻", description: "技術・プログラミング" },
-  { slug: "side-business", name: "副業", icon: "💼", description: "副収入・フリーランス" },
-  { slug: "parenting", name: "子育て", icon: "👶", description: "育児・ワークライフバランス" },
+  { slug: "investment", name: "投資", icon: "💰", description: "資産形成・インデックス投資", className: "category-btn-investment" },
+  { slug: "engineering", name: "ITエンジニア", icon: "💻", description: "技術・プログラミング", className: "category-btn-engineering" },
+  { slug: "side-business", name: "副業", icon: "💼", description: "副収入・フリーランス", className: "category-btn-side-business" },
+  { slug: "parenting", name: "子育て", icon: "👶", description: "育児・ワークライフバランス", className: "category-btn-parenting" },
 ];
 
 export default function Home() {
@@ -26,7 +26,7 @@ export default function Home() {
             <Link
               key={category.slug}
               href={`/category/${category.slug}`}
-              className="group block p-3 md:p-6 bg-white border-2 border-gray-200 rounded-lg hover:border-primary hover:shadow-lg transition-all duration-200"
+              className={`group block p-3 md:p-6 bg-white border-2 rounded-lg hover:shadow-lg transition-all duration-200 ${category.className}`}
             >
               <div className="flex items-center gap-2 md:gap-4">
                 <span className="text-2xl md:text-4xl">{category.icon}</span>

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -134,7 +134,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
       {/* 記事ヘッダー */}
       <article className={`max-w-3xl mx-auto ${categoryClass}`}>
         <header className="mb-8">
-          <h1 className="post-title text-xl md:text-2xl font-bold mb-4 leading-tight">{post.title}</h1>
+          <h1 className="post-title text-xl md:text-2xl font-bold mb-6 leading-relaxed">{post.title}</h1>
 
           <div className="flex items-center gap-4 text-sm text-gray-600">
             <time>{formattedDate}</time>
@@ -150,7 +150,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         {/* 目次 */}
         {tocItems.length > 0 && (
           <div className="post-toc mb-8 p-4">
-            <TableOfContents items={tocItems} />
+            <TableOfContents items={tocItems} category={post.category} />
           </div>
         )}
 

--- a/components/ArticleCard.tsx
+++ b/components/ArticleCard.tsx
@@ -16,10 +16,10 @@ interface ArticleCardProps {
 }
 
 const categoryColors: Record<string, string> = {
-  "投資": "bg-blue-100 text-blue-800",
-  "子育て": "bg-pink-100 text-pink-800",
-  "ITエンジニア": "bg-green-100 text-green-800",
-  "副業": "bg-purple-100 text-purple-800",
+  "投資": "bg-blue-500 text-white border-blue-600",
+  "子育て": "bg-pink-500 text-white border-pink-600",
+  "ITエンジニア": "bg-green-500 text-white border-green-600",
+  "副業": "bg-purple-500 text-white border-purple-600",
 };
 
 export default function ArticleCard({ post }: ArticleCardProps) {
@@ -29,7 +29,7 @@ export default function ArticleCard({ post }: ArticleCardProps) {
     <Link href={`/posts/${post.slug}`}>
       <article className="card p-6 h-full flex flex-col">
         <div className="flex items-center gap-3 mb-3">
-          <span className={`px-3 py-1 rounded-full text-xs font-medium ${categoryColors[post.category] || "bg-gray-100 text-gray-800"}`}>
+          <span className={`px-4 py-1.5 rounded-md text-sm font-bold border-2 shadow-sm ${categoryColors[post.category] || "bg-gray-100 text-gray-800 border-gray-300"}`}>
             {post.category}
           </span>
           <time className="text-sm text-gray-500">{formattedDate}</time>

--- a/components/TableOfContents.tsx
+++ b/components/TableOfContents.tsx
@@ -5,10 +5,27 @@ import { TocItem } from "@/lib/toc";
 
 interface TableOfContentsProps {
   items: TocItem[];
+  category?: string;
 }
 
-export default function TableOfContents({ items }: TableOfContentsProps) {
+const categoryActiveColors: Record<string, string> = {
+  "投資": "text-blue-600 font-bold border-l-4 border-blue-600 pl-2 -ml-2",
+  "子育て": "text-pink-600 font-bold border-l-4 border-pink-600 pl-2 -ml-2",
+  "ITエンジニア": "text-green-600 font-bold border-l-4 border-green-600 pl-2 -ml-2",
+  "副業": "text-purple-600 font-bold border-l-4 border-purple-600 pl-2 -ml-2",
+};
+
+const categoryHoverColors: Record<string, string> = {
+  "投資": "hover:text-blue-600",
+  "子育て": "hover:text-pink-600",
+  "ITエンジニア": "hover:text-green-600",
+  "副業": "hover:text-purple-600",
+};
+
+export default function TableOfContents({ items, category }: TableOfContentsProps) {
   const [activeId, setActiveId] = useState<string>("");
+  const activeColor = category ? categoryActiveColors[category] : "text-primary font-medium";
+  const hoverColor = category ? categoryHoverColors[category] : "hover:text-primary";
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -61,8 +78,8 @@ export default function TableOfContents({ items }: TableOfContentsProps) {
               onClick={(e) => handleClick(e, item.id)}
               className={`text-sm block py-1 transition-colors ${
                 activeId === item.id
-                  ? "text-primary font-medium"
-                  : "text-gray-600 hover:text-primary"
+                  ? activeColor
+                  : `text-gray-600 ${hoverColor}`
               }`}
             >
               {item.text}


### PR DESCRIPTION
- トップページのカテゴリーボタンにカテゴリ固有の色を追加
- 記事カードのカテゴリタグをより目立つデザインに変更（大きく、ボーダー付き、シャドウ付き）
- 目次のアクティブリンクにカテゴリカラーとボーダーを追加
- 記事タイトルのパディングと行間を調整して読みやすさを向上
- カテゴリページのヘッダーとパンくずリストにカテゴリカラーを適用