### PR TITLE
見出しスタイルの適用を修正

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -147,7 +147,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
             return (
               <>
                 <div
-                  className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
+                  className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
                   dangerouslySetInnerHTML={{ __html: content }}
                 />
               </>
@@ -187,7 +187,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
             segments.push(
               <div
                 key={`content-${i}`}
-                className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
+                className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
                 dangerouslySetInnerHTML={{ __html: segmentContent }}
               />
             );


### PR DESCRIPTION
記事本文のdivに重複してcategoryClassが適用されていたため、
CSSセレクタ .post-category-XXX .prose h2 が正しく機能していなかった。

articleタグにのみcategoryClassを適用することで、
全カテゴリで見出しのスタイルが正しく表示されるように修正。