### PR TITLE
最後のproseセグメントからcategoryClassを削除

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -223,7 +223,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           segments.push(
             <div
               key={`content-last`}
-              className={`prose prose-lg max-w-none prose-headings:scroll-mt-20 ${categoryClass}`}
+              className="prose prose-lg max-w-none prose-headings:scroll-mt-20"
               dangerouslySetInnerHTML={{ __html: lastSegment }}
             />
           );


### PR DESCRIPTION
問題:
- 記事の最後のセグメントのproseタグにcategoryClassが残っていた
- これによりカテゴリごとの見出しスタイルが正しく適用されない原因となっていた

修正:
- app/posts/[slug]/page.tsx の226行目からcategoryClassを削除
- categoryClassはarticleタグのみに適用し、prose divには適用しない