### PR TITLE
ページネーションページのカテゴリボタンを2列表示に修正

### DIFF
--- a/app/page/[page]/page.tsx
+++ b/app/page/[page]/page.tsx
@@ -6,10 +6,10 @@ import { Metadata } from "next";
 import Link from "next/link";
 
 const categories = [
-  { slug: "investment", name: "投資", icon: "💰", description: "資産形成・インデックス投資" },
-  { slug: "engineering", name: "ITエンジニア", icon: "💻", description: "技術・プログラミング" },
-  { slug: "side-business", name: "副業", icon: "💼", description: "副収入・フリーランス" },
-  { slug: "parenting", name: "子育て", icon: "👶", description: "育児・ワークライフバランス" },
+  { slug: "investment", name: "投資", icon: "💰", description: "資産形成・インデックス投資", className: "category-btn-investment" },
+  { slug: "engineering", name: "ITエンジニア", icon: "💻", description: "技術・プログラミング", className: "category-btn-engineering" },
+  { slug: "side-business", name: "副業", icon: "💼", description: "副収入・フリーランス", className: "category-btn-side-business" },
+  { slug: "parenting", name: "子育て", icon: "👶", description: "育児・ワークライフバランス", className: "category-btn-parenting" },
 ];
 
 export async function generateStaticParams() {
@@ -46,23 +46,23 @@ export default async function PagedHome({ params }: { params: Promise<{ page: st
       {/* カテゴリーボタン */}
       <div className="mb-12">
         <h2 className="text-2xl font-bold mb-6 text-center">カテゴリーから探す</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-3 md:gap-4">
           {categories.map((category) => (
             <Link
               key={category.slug}
               href={`/category/${category.slug}`}
-              className="group block p-6 bg-white border-2 border-gray-200 rounded-lg hover:border-primary hover:shadow-lg transition-all duration-200"
+              className={`group block p-3 md:p-6 bg-white border-2 rounded-lg hover:shadow-lg transition-all duration-200 ${category.className}`}
             >
-              <div className="flex items-center gap-4">
-                <span className="text-4xl">{category.icon}</span>
-                <div className="flex-1">
-                  <h3 className="text-xl font-bold text-gray-900 group-hover:text-primary transition-colors">
+              <div className="flex items-center gap-2 md:gap-4">
+                <span className="text-2xl md:text-4xl">{category.icon}</span>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm md:text-xl font-bold text-gray-900 group-hover:text-primary transition-colors">
                     {category.name}
                   </h3>
-                  <p className="text-sm text-gray-600 mt-1">{category.description}</p>
+                  <p className="text-xs md:text-sm text-gray-600 mt-0.5 md:mt-1 truncate">{category.description}</p>
                 </div>
                 <svg
-                  className="w-6 h-6 text-gray-400 group-hover:text-primary group-hover:translate-x-1 transition-all"
+                  className="w-4 h-4 md:w-6 md:h-6 text-gray-400 group-hover:text-primary group-hover:translate-x-1 transition-all flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"


### PR DESCRIPTION
問題:
- 2ページ目以降のカテゴリボタンが1列表示になっていた
- トップページと2ページ目以降でグリッド設定が異なっていた

修正:
- grid-cols-1 md:grid-cols-2 → grid-cols-2 に変更（常に2列）
- カテゴリにclassNameプロパティを追加してボーダー色を適用
- レスポンシブ対応のスタイル調整（gap、padding、font-sizeなど）
- トップページと完全に統一