### PR TITLE
記事ごとのSEO最適化を実装

### DIFF
--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -3,6 +3,7 @@ import ArticleCard from "@/components/ArticleCard";
 import Pagination from "@/components/Pagination";
 import { getPaginatedPosts, getTotalPages, POSTS_PER_PAGE } from "@/lib/pagination";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/JsonLd";
 
 const categories: Record<string, string> = {
   "investment": "投資",
@@ -80,8 +81,16 @@ export default async function CategoryPage({ params }: { params: Promise<{ slug:
   const headerColor = categoryHeaderColors[slug] || "bg-gray-700 text-white";
   const categoryColor = categoryColors[slug] || "bg-gray-100 text-gray-800 border-gray-300";
 
+  // パンくずリストデータ
+  const breadcrumbItems = [
+    { name: "ホーム", url: "https://blog.nexeed-web.com" },
+    { name: categoryName, url: `https://blog.nexeed-web.com/category/${slug}` },
+  ];
+
   return (
-    <div className="container-custom py-12">
+    <>
+      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <div className="container-custom py-12">
       {/* パンくずリスト */}
       <nav className="text-sm text-gray-500 mb-8">
         <Link href="/" className="hover:text-primary">Home</Link>
@@ -107,6 +116,7 @@ export default async function CategoryPage({ params }: { params: Promise<{ slug:
           <p>まだ記事がありません。</p>
         </div>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/app/category/[slug]/page/[page]/page.tsx
+++ b/app/category/[slug]/page/[page]/page.tsx
@@ -4,6 +4,7 @@ import Pagination from "@/components/Pagination";
 import { getPaginatedPosts, getTotalPages, POSTS_PER_PAGE } from "@/lib/pagination";
 import { Metadata } from "next";
 import Link from "next/link";
+import { BreadcrumbJsonLd } from "@/components/JsonLd";
 
 const categories: Record<string, string> = {
   "investment": "投資",
@@ -93,8 +94,16 @@ export default async function CategoryPagedPage({ params }: { params: Promise<{ 
   const headerColor = categoryHeaderColors[slug] || "bg-gray-700 text-white";
   const categoryColor = categoryColors[slug] || "bg-gray-100 text-gray-800 border-gray-300";
 
+  // パンくずリストデータ
+  const breadcrumbItems = [
+    { name: "ホーム", url: "https://blog.nexeed-web.com" },
+    { name: categoryName, url: `https://blog.nexeed-web.com/category/${slug}` },
+  ];
+
   return (
-    <div className="container-custom py-12">
+    <>
+      <BreadcrumbJsonLd items={breadcrumbItems} />
+      <div className="container-custom py-12">
       {/* パンくずリスト */}
       <nav className="text-sm text-gray-500 mb-8">
         <Link href="/" className="hover:text-primary">Home</Link>
@@ -120,6 +129,7 @@ export default async function CategoryPagedPage({ params }: { params: Promise<{ 
           <p>まだ記事がありません。</p>
         </div>
       )}
-    </div>
+      </div>
+    </>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { ja } from "date-fns/locale";
 import ArticleCard from "@/components/ArticleCard";
 import TableOfContents from "@/components/TableOfContents";
 import { extractTocFromHtml } from "@/lib/toc";
-import { BlogPostJsonLd } from "@/components/JsonLd";
+import { BlogPostJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import Link from "next/link";
 import A8Banner from "@/components/A8Banner";
 import MoshimoBanner from "@/components/MoshimoBanner";
@@ -35,6 +35,8 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     ...(categoryKeywords[post.category] || []),
   ];
 
+  const ogImageUrl = `https://blog.nexeed-web.com/posts/${slug}/opengraph-image`;
+
   return {
     title: `${post.title} | NEXEED BLOG`,
     description: post.excerpt,
@@ -50,15 +52,27 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       section: post.category,
       tags: keywords,
       locale: "ja_JP",
+      images: [
+        {
+          url: ogImageUrl,
+          width: 1200,
+          height: 630,
+          alt: post.title,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
       title: post.title,
       description: post.excerpt,
       creator: "@nexeed_blog",
+      images: [ogImageUrl],
     },
     alternates: {
       canonical: `https://blog.nexeed-web.com/posts/${slug}`,
+      languages: {
+        "ja-JP": `https://blog.nexeed-web.com/posts/${slug}`,
+      },
     },
   };
 }
@@ -111,6 +125,13 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     bannerPair = moshimoBannerPair || a8BannerPair;
   }
 
+  // パンくずリストデータ
+  const breadcrumbItems = [
+    { name: "ホーム", url: "https://blog.nexeed-web.com" },
+    { name: post.category, url: `https://blog.nexeed-web.com/category/${encodeURIComponent(post.category)}` },
+    { name: post.title, url: `https://blog.nexeed-web.com/posts/${slug}` },
+  ];
+
   return (
     <>
       <BlogPostJsonLd
@@ -120,7 +141,9 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         dateModified={post.updated}
         url={`https://blog.nexeed-web.com/posts/${slug}`}
         category={post.category}
+        imageUrl={`https://blog.nexeed-web.com/posts/${slug}/opengraph-image`}
       />
+      <BreadcrumbJsonLd items={breadcrumbItems} />
       <div className="container-custom py-12">
         {/* パンくずリスト */}
         <nav className="text-sm text-gray-500 mb-8">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/"],
     },
-    sitemap: "https://nexeed-blog.vercel.app/sitemap.xml",
+    sitemap: "https://blog.nexeed-web.com/sitemap.xml",
   };
 }

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -48,6 +48,7 @@ export function BlogPostJsonLd({
   dateModified,
   url,
   category,
+  imageUrl,
 }: {
   title: string;
   description: string;
@@ -55,12 +56,14 @@ export function BlogPostJsonLd({
   dateModified?: string;
   url: string;
   category: string;
+  imageUrl?: string;
 }) {
   const data = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: title,
     description: description,
+    image: imageUrl || `${url}/opengraph-image`,
     datePublished: datePublished,
     dateModified: dateModified || datePublished,
     author: {
@@ -89,6 +92,25 @@ export function BlogPostJsonLd({
       name: "NEXEED BLOG",
       url: "https://blog.nexeed-web.com",
     },
+  };
+
+  return <JsonLd data={data} />;
+}
+
+export function BreadcrumbJsonLd({
+  items,
+}: {
+  items: Array<{ name: string; url: string }>;
+}) {
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
   };
 
   return <JsonLd data={data} />;


### PR DESCRIPTION
## 変更内容

### 1. サイトマップURL修正
- robots.tsのsitemapURLをVercelから正式ドメイン(blog.nexeed-web.com)に修正

### 2. JSON-LD構造化データの強化
- BlogPostJsonLdにimageフィールドを追加し、OG画像を含めるように改善
- BreadcrumbJsonLdコンポーネントを新規追加
  - パンくずリストの構造化データを提供
  - SEOとGoogle検索結果の改善に貢献

### 3. 記事ページのメタデータ強化
- OpenGraphにimagesフィールドを明示的に追加
  - OG画像のURL、サイズ(1200x630)、alt属性を設定
- Twitter Cardにimagesフィールドを追加
- alternatesにlanguages設定を追加（ja-JP）
- BlogPostJsonLdにimageUrlパラメータを渡すように修正
- BreadcrumbJsonLdを記事ページに実装

### 4. カテゴリページのSEO改善
- 全カテゴリページにBreadcrumbJsonLdを追加
- ページネーションページにもBreadcrumbJsonLdを実装

## SEO改善効果

- 検索エンジンによる画像認識の向上
- SNSシェア時のOG画像表示の確実性向上
- パンくずリスト構造化データによる検索結果の改善
- サイトマップURLの正確性向上
- 各記事の言語設定の明確化

これらの変更により、検索エンジンでの表示ランクとクリック率の向上が期待できます。