### PR TITLE
リード文セクションに「この記事でわかること」を含めるよう改善

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -170,11 +170,30 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           </div>
 
           {/* リード文 */}
-          {post.excerpt && (
-            <p className="text-gray-700 leading-relaxed text-base mb-8 p-4 bg-gray-50 rounded-lg border-l-4 border-primary">
-              {post.excerpt}
-            </p>
-          )}
+          {(() => {
+            // 「この記事でわかること」セクションを抽出
+            const content = post.content || "";
+            const leadSectionMatch = content.match(
+              /<p><strong>この記事でわかること:?<\/strong><\/p>\s*<ul>[\s\S]*?<\/ul>/i
+            );
+            const leadSectionHtml = leadSectionMatch ? leadSectionMatch[0] : "";
+
+            return (
+              <div className="mb-8 p-6 bg-gray-50 rounded-lg border-l-4 border-primary">
+                {post.excerpt && (
+                  <p className="text-gray-700 leading-relaxed text-base mb-4">
+                    {post.excerpt}
+                  </p>
+                )}
+                {leadSectionHtml && (
+                  <div
+                    className="prose prose-base max-w-none [&_strong]:text-gray-900 [&_ul]:my-2 [&_li]:text-gray-700"
+                    dangerouslySetInnerHTML={{ __html: leadSectionHtml }}
+                  />
+                )}
+              </div>
+            );
+          })()}
         </header>
 
         {/* 目次 */}
@@ -190,6 +209,11 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
           let content = post.content || "";
           // 最初のH1タグを削除（タイトルの重複を防ぐため）
           content = content.replace(/^<h1[^>]*>.*?<\/h1>\s*/i, "");
+          // 「この記事でわかること」セクションを削除（リード文エリアに表示済みのため）
+          content = content.replace(
+            /<p><strong>この記事でわかること:?<\/strong><\/p>\s*<ul>[\s\S]*?<\/ul>\s*/i,
+            ""
+          );
 
           if (!bannerPair) {
             // バナーがない場合は通常表示


### PR DESCRIPTION
記事の導入部分をより充実させるために以下の変更を実施：
- リード文エリアにexcerptと「この記事でわかること」リストの両方を表示
- 記事本文から「この記事でわかること」セクションを削除して重複を防止
- リード文エリア全体を統一されたデザインボックスに配置

これにより、読者は以下の順で情報を得られるようになりました：
1. タイトル
2. リード文（記事概要 + この記事でわかること）
3. 目次
4. 本文

読者が記事の価値を最初に明確に把握できるようになり、読み進めるかの判断がしやすくなります。