### PR TITLE
記事一覧を一列表示に変更

### DIFF
--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -104,7 +104,7 @@ export default async function CategoryPage({ params }: { params: Promise<{ slug:
 
       {posts.length > 0 ? (
         <>
-          <div className="grid gap-8 md:grid-cols-2">
+          <div className="grid gap-8">
             {posts.map((post) => (
               <ArticleCard key={post.slug} post={post} />
             ))}

--- a/app/category/[slug]/page/[page]/page.tsx
+++ b/app/category/[slug]/page/[page]/page.tsx
@@ -117,7 +117,7 @@ export default async function CategoryPagedPage({ params }: { params: Promise<{ 
 
       {posts.length > 0 ? (
         <>
-          <div className="grid gap-8 md:grid-cols-2">
+          <div className="grid gap-8">
             {posts.map((post) => (
               <ArticleCard key={post.slug} post={post} />
             ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
       </div>
 
       <h1 className="text-4xl font-bold mb-8 text-center">最新記事</h1>
-      <div className="grid gap-8 md:grid-cols-2">
+      <div className="grid gap-8">
         {posts.map((post) => (
           <ArticleCard key={post.slug} post={post} />
         ))}

--- a/app/page/[page]/page.tsx
+++ b/app/page/[page]/page.tsx
@@ -76,7 +76,7 @@ export default async function PagedHome({ params }: { params: Promise<{ page: st
       </div>
 
       <h1 className="text-4xl font-bold mb-8 text-center">最新記事</h1>
-      <div className="grid gap-8 md:grid-cols-2">
+      <div className="grid gap-8">
         {posts.map((post) => (
           <ArticleCard key={post.slug} post={post} />
         ))}

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -386,7 +386,7 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
       {relatedPosts.length > 0 && (
         <div className="mt-16">
           <h2 className="text-2xl font-bold mb-6">関連記事</h2>
-          <div className="grid gap-6 md:grid-cols-3">
+          <div className="grid gap-6">
             {relatedPosts.map((relatedPost) => (
               <ArticleCard key={relatedPost.slug} post={relatedPost} />
             ))}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -58,7 +58,7 @@ function SearchResults() {
           <p>検索キーワードを入力してください。</p>
         </div>
       ) : results.length > 0 ? (
-        <div className="grid gap-8 md:grid-cols-2">
+        <div className="grid gap-8">
           {results.map((post) => (
             <ArticleCard key={post.slug} post={post} />
           ))}


### PR DESCRIPTION
- すべてのページで記事一覧を二列から一列表示に変更
- 対象ページ：
  - トップページ (app/page.tsx)
  - ページネーション (app/page/[page]/page.tsx)
  - カテゴリーページ (app/category/[slug]/page.tsx)
  - カテゴリーページネーション (app/category/[slug]/page/[page]/page.tsx)
  - 検索ページ (app/search/page.tsx)
  - 記事詳細の関連記事セクション (app/posts/[slug]/page.tsx)
- 横並びレイアウトと合わせて、より見やすい一列表示を実現