### PR TITLE
バナー表示順序を変更：タイトルを最初に表示

### DIFF
--- a/components/A8Banner.tsx
+++ b/components/A8Banner.tsx
@@ -23,15 +23,15 @@ export default function A8Banner({
 }: A8BannerProps) {
   return (
     <div className="my-6">
-      {/* PR表記 */}
-      <div className="text-xs text-gray-500 mb-2">
-        <span className="px-2 py-1 bg-gray-100 rounded">PR・広告</span>
-      </div>
-
       {/* タイトル（オプション） */}
       {title && (
         <h4 className="text-sm font-medium text-gray-700 mb-3 whitespace-pre-line text-center">{title}</h4>
       )}
+
+      {/* PR表記 */}
+      <div className="text-xs text-gray-500 mb-2">
+        <span className="px-2 py-1 bg-gray-100 rounded">PR・広告</span>
+      </div>
 
       {/* PC用バナー（md:以上で表示） */}
       <a

--- a/components/MoshimoBanner.tsx
+++ b/components/MoshimoBanner.tsx
@@ -23,15 +23,15 @@ export default function MoshimoBanner({
 }: MoshimoBannerProps) {
   return (
     <div className="my-6">
-      {/* PR表記 */}
-      <div className="text-xs text-gray-500 mb-2">
-        <span className="px-2 py-1 bg-gray-100 rounded">PR・広告</span>
-      </div>
-
       {/* タイトル（オプション） */}
       {title && (
         <h4 className="text-sm font-medium text-gray-700 mb-3 whitespace-pre-line text-center">{title}</h4>
       )}
+
+      {/* PR表記 */}
+      <div className="text-xs text-gray-500 mb-2">
+        <span className="px-2 py-1 bg-gray-100 rounded">PR・広告</span>
+      </div>
 
       {/* PC用バナー（md:以上で表示） */}
       <a


### PR DESCRIPTION
- MoshimoBannerとA8Bannerでタイトルを最初に表示するよう変更
- 表示順序：タイトル → PR表記 → バナー画像
- PyQバナーの表示：「PyQ（パイキュー）に興味がある方は↓下のリンクをクリック↓」→「PR・広告」→バナー