### PR TITLE
すべての記事にクリック促進文言を実装

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -125,10 +125,11 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     bannerPair = moshimoBannerPair || a8BannerPair;
   }
 
-  // バナーのタイトルを設定（PyQの場合は特別な文言）
+  // バナーのタイトルを設定（すべてのバナーで表示）
   let bannerTitle: string | undefined;
-  if (post.affiliateBannerId && post.affiliateBannerId.startsWith('pyq-')) {
-    bannerTitle = 'PyQ（パイキュー）に興味がある方は\n↓下のリンクをクリック↓';
+  if (bannerPair) {
+    const serviceName = bannerPair.desktop.name;
+    bannerTitle = `${serviceName}に興味がある方は\n↓下のリンクをクリック↓`;
   }
 
   // パンくずリストデータ


### PR DESCRIPTION
- PyQ専用からすべてのバナーに機能を拡張
- サービス名を動的に取得してタイトルに埋め込む
- 文言：「{サービス名}に興味がある方は↓下のリンクをクリック↓」
- 例：「PyQ（パイキュー）に興味がある方は↓下のリンクをクリック↓」
- 各記事のバナーで自動的にサービス名が表示される