### PR TITLE
Instagram用シェアボタンを追加

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { BlogPostJsonLd, BreadcrumbJsonLd } from "@/components/JsonLd";
 import Link from "next/link";
 import A8Banner from "@/components/A8Banner";
 import MoshimoBanner from "@/components/MoshimoBanner";
+import ShareButtons from "@/components/ShareButtons";
 import { getResponsiveBanners, getResponsiveMoshimoBanners, getBannerPairById } from "@/data/affiliate-links";
 
 export async function generateStaticParams() {
@@ -354,41 +355,10 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
         })()}
 
         {/* SNSシェアボタン */}
-        <div className="mt-12 pt-8 border-t border-gray-200">
-          <h3 className="text-lg font-bold mb-4">この記事をシェア</h3>
-          <div className="flex gap-4">
-            <a
-              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(post.title)}&url=${encodeURIComponent(`https://blog.nexeed-web.com/posts/${slug}`)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800 transition-colors"
-            >
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-              </svg>
-              X
-            </a>
-            <a
-              href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(`https://blog.nexeed-web.com/posts/${slug}`)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
-              </svg>
-              Facebook
-            </a>
-            <a
-              href={`https://b.hatena.ne.jp/entry/${encodeURIComponent(`https://blog.nexeed-web.com/posts/${slug}`)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-sky-500 text-white rounded-md hover:bg-sky-600 transition-colors"
-            >
-              はてブ
-            </a>
-          </div>
-        </div>
+        <ShareButtons
+          title={post.title}
+          url={`https://blog.nexeed-web.com/posts/${slug}`}
+        />
       </article>
 
       {/* 関連記事 */}

--- a/components/ShareButtons.tsx
+++ b/components/ShareButtons.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+interface ShareButtonsProps {
+  title: string;
+  url: string;
+}
+
+export default function ShareButtons({ title, url }: ShareButtonsProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  const handleWebShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: title,
+          url: url,
+        });
+      } catch (err) {
+        console.error('Error sharing:', err);
+      }
+    }
+  };
+
+  // Web Share APIが使用可能かチェック
+  const canShare = typeof navigator !== 'undefined' && navigator.share;
+
+  return (
+    <div className="mt-12 pt-8 border-t border-gray-200">
+      <h3 className="text-lg font-bold mb-4">この記事をシェア</h3>
+      <div className="flex flex-wrap gap-4">
+        {/* X (Twitter) */}
+        <a
+          href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(url)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-4 py-2 bg-black text-white rounded-md hover:bg-gray-800 transition-colors"
+          aria-label="Xでシェア"
+        >
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+          </svg>
+          X
+        </a>
+
+        {/* Facebook */}
+        <a
+          href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          aria-label="Facebookでシェア"
+        >
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+          </svg>
+          Facebook
+        </a>
+
+        {/* はてなブックマーク */}
+        <a
+          href={`https://b.hatena.ne.jp/entry/${encodeURIComponent(url)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 px-4 py-2 bg-sky-500 text-white rounded-md hover:bg-sky-600 transition-colors"
+          aria-label="はてなブックマークに追加"
+        >
+          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4.5 0C2.0 0 0 2.0 0 4.5v15C0 22.0 2.0 24 4.5 24h15c2.5 0 4.5-2.0 4.5-4.5v-15C24 2.0 22.0 0 19.5 0h-15zm9.75 3.75c1.25 0 2.25 1.0 2.25 2.25s-1.0 2.25-2.25 2.25-2.25-1.0-2.25-2.25 1.0-2.25 2.25-2.25zm-4.5 3.0h3.0v8.0c0 1.25-1.0 2.25-2.25 2.25h-3.0c-1.25 0-2.25-1.0-2.25-2.25v-6.0c0-1.25 1.0-2.25 2.25-2.25h2.25v6.0zm4.5 4.5c1.25 0 2.25 1.0 2.25 2.25v3.0c0 1.25-1.0 2.25-2.25 2.25s-2.25-1.0-2.25-2.25v-3.0c0-1.25 1.0-2.25 2.25-2.25z"/>
+          </svg>
+          はてブ
+        </a>
+
+        {/* Web Share API (モバイルでInstagramを含む共有メニュー) */}
+        {canShare && (
+          <button
+            onClick={handleWebShare}
+            className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-purple-500 via-pink-500 to-orange-500 text-white rounded-md hover:from-purple-600 hover:via-pink-600 hover:to-orange-600 transition-colors"
+            aria-label="共有メニューを開く"
+          >
+            <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"/>
+            </svg>
+            共有
+          </button>
+        )}
+
+        {/* URLコピー (Instagramアイコン) */}
+        <button
+          onClick={handleCopyUrl}
+          className={`flex items-center gap-2 px-4 py-2 rounded-md transition-colors ${
+            copied
+              ? 'bg-green-500 text-white'
+              : 'bg-gradient-to-br from-purple-600 via-pink-500 to-orange-400 text-white hover:from-purple-700 hover:via-pink-600 hover:to-orange-500'
+          }`}
+          aria-label="URLをコピー"
+        >
+          {copied ? (
+            <>
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              コピー完了
+            </>
+          ) : (
+            <>
+              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+              </svg>
+              Instagram用
+            </>
+          )}
+        </button>
+      </div>
+      {copied && (
+        <p className="text-sm text-green-600 mt-2">URLをコピーしました。Instagramアプリで投稿に貼り付けてください。</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- ShareButtonsコンポーネントを新規作成
- Web Share API対応（モバイルでInstagramアプリを含む共有メニュー表示）
- URLコピーボタン追加（Instagram用）
- X、Facebook、はてなブックマークも統合

https://claude.ai/code/session_011VLpUKYpd2RbNaR16p2S3b