### PR TITLE
SEO設定の改善: パンくずリストURL修正、JSON-LDロゴ修正、RSSフィード強化

### DIFF
--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -61,9 +61,10 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       locale: "ja_JP",
     },
     twitter: {
-      card: "summary",
+      card: "summary_large_image",
       title: `${categoryName}の記事一覧`,
       description: categoryDescriptions[slug] || `${categoryName}に関する記事の一覧ページです。`,
+      creator: "@nexeed_blog",
     },
     alternates: {
       canonical: `https://blog.nexeed-web.com/category/${slug}`,

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -9,10 +9,19 @@ export async function GET() {
   <channel>
     <title>NEXEED BLOG</title>
     <link>${baseUrl}</link>
-    <description>投資、子育て、ITエンジニア、副業をテーマにした個人ブログ</description>
+    <description>投資、子育て、ITエンジニア、副業をテーマにした個人ブログ。実体験と統計データに基づいた信頼性の高い情報を提供します。</description>
     <language>ja</language>
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml"/>
+    <managingEditor>nexeed-blog@example.com (大島直孝)</managingEditor>
+    <webMaster>nexeed-blog@example.com (大島直孝)</webMaster>
+    <copyright>Copyright ${new Date().getFullYear()} NEXEED BLOG</copyright>
+    <ttl>60</ttl>
+    <image>
+      <url>${baseUrl}/NexeedBlog.png</url>
+      <title>NEXEED BLOG</title>
+      <link>${baseUrl}</link>
+    </image>
     ${posts
       .map(
         (post) => `
@@ -21,8 +30,9 @@ export async function GET() {
       <link>${baseUrl}/posts/${post.slug}</link>
       <description>${escapeXml(post.excerpt)}</description>
       <pubDate>${new Date(post.date).toUTCString()}</pubDate>
-      <guid>${baseUrl}/posts/${post.slug}</guid>
+      <guid isPermaLink="true">${baseUrl}/posts/${post.slug}</guid>
       <category>${escapeXml(post.category)}</category>
+      <author>nexeed-blog@example.com (大島直孝)</author>
     </item>`
       )
       .join("")}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -54,9 +54,10 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
-  verification: {
-    google: "google-site-verification-code-here", // Google Search Consoleで取得したコードに置き換え
-  },
+  // Google Search Console認証は.envまたはGoogle Tag Manager経由で設定推奨
+  // verification: {
+  //   google: "YOUR_GOOGLE_SITE_VERIFICATION_CODE",
+  // },
   icons: {
     icon: "/NexeedBlog.png",
     apple: "/NexeedBlog.png",

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -92,6 +92,14 @@ const categoryClasses: Record<string, string> = {
   "副業": "post-category-side-business",
 };
 
+// 日本語カテゴリー名から英語スラッグへのマッピング
+const categoryToSlug: Record<string, string> = {
+  "投資": "investment",
+  "子育て": "parenting",
+  "ITエンジニア": "engineering",
+  "副業": "side-business",
+};
+
 export default async function PostPage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const post = await getPostBySlug(slug);
@@ -133,10 +141,11 @@ export default async function PostPage({ params }: { params: Promise<{ slug: str
     bannerTitle = `${serviceName}に興味がある方は\n↓下のリンクをクリック↓`;
   }
 
-  // パンくずリストデータ
+  // パンくずリストデータ（カテゴリーURLは英語スラッグを使用）
+  const categorySlug = categoryToSlug[post.category] || "investment";
   const breadcrumbItems = [
     { name: "ホーム", url: "https://blog.nexeed-web.com" },
-    { name: post.category, url: `https://blog.nexeed-web.com/category/${encodeURIComponent(post.category)}` },
+    { name: post.category, url: `https://blog.nexeed-web.com/category/${categorySlug}` },
     { name: post.title, url: `https://blog.nexeed-web.com/posts/${slug}` },
   ];
 

--- a/components/JsonLd.tsx
+++ b/components/JsonLd.tsx
@@ -76,7 +76,7 @@ export function BlogPostJsonLd({
       name: "NEXEED BLOG",
       logo: {
         "@type": "ImageObject",
-        url: "https://blog.nexeed-web.com/logo.png",
+        url: "https://blog.nexeed-web.com/NexeedBlog.png",
       },
     },
     url: url,


### PR DESCRIPTION
- パンくずリストのカテゴリーURLを英語スラッグに統一
- JSON-LDのロゴURLを実在するファイル(NexeedBlog.png)に修正
- カテゴリーページのTwitterカードをsummary_large_imageに変更
- RSSフィードに著者情報、画像、著作権情報を追加
- Google Search Console認証コードのプレースホルダーをコメント化

https://claude.ai/code/session_01UHzE9PpAgEWgvR2z7vZBL9