### PR TITLE
fix: リダイレクト問題の修正（Google Search Console対応）

### DIFF
--- a/app/category/[slug]/page/[page]/page.tsx
+++ b/app/category/[slug]/page/[page]/page.tsx
@@ -5,6 +5,7 @@ import { getPaginatedPosts, getTotalPages, POSTS_PER_PAGE } from "@/lib/paginati
 import { Metadata } from "next";
 import Link from "next/link";
 import { BreadcrumbJsonLd } from "@/components/JsonLd";
+import { redirect, notFound } from "next/navigation";
 
 const categories: Record<string, string> = {
   "investment": "投資",
@@ -96,9 +97,26 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
 export default async function CategoryPagedPage({ params }: { params: Promise<{ slug: string; page: string }> }) {
   const { slug, page } = await params;
   const pageNumber = parseInt(page);
+
+  // /category/[slug]/page/1 はカテゴリートップにリダイレクト（重複コンテンツ防止）
+  if (pageNumber === 1) {
+    redirect(`/category/${slug}`);
+  }
+
   const categoryName = categories[slug];
+
+  // 存在しないカテゴリーは404
+  if (!categoryName) {
+    notFound();
+  }
+
   const allPosts = getPostsByCategory(categoryName);
   const totalPages = getTotalPages(allPosts.length, POSTS_PER_PAGE);
+
+  // 範囲外のページ番号は404
+  if (pageNumber < 1 || pageNumber > totalPages || isNaN(pageNumber)) {
+    notFound();
+  }
   const posts = getPaginatedPosts(allPosts, pageNumber, POSTS_PER_PAGE);
 
   const headerColor = categoryHeaderColors[slug] || "bg-gray-700 text-white";

--- a/app/page/[page]/page.tsx
+++ b/app/page/[page]/page.tsx
@@ -4,6 +4,7 @@ import Pagination from "@/components/Pagination";
 import { getPaginatedPosts, getTotalPages, POSTS_PER_PAGE } from "@/lib/pagination";
 import { Metadata } from "next";
 import Link from "next/link";
+import { redirect, notFound } from "next/navigation";
 
 const categories = [
   { slug: "investment", name: "投資", icon: "💰", description: "資産形成・インデックス投資", className: "category-btn-investment" },
@@ -30,6 +31,9 @@ export async function generateMetadata({ params }: { params: Promise<{ page: str
   return {
     title: `記事一覧 - ${page}ページ目 | NEXEED BLOG`,
     description: `NEXEED BLOGの記事一覧${page}ページ目です。`,
+    alternates: {
+      canonical: `https://blog.nexeed-web.com/page/${page}`,
+    },
   };
 }
 
@@ -37,8 +41,18 @@ export default async function PagedHome({ params }: { params: Promise<{ page: st
   const { page } = await params;
   const pageNumber = parseInt(page);
 
+  // /page/1 はホームページにリダイレクト（重複コンテンツ防止）
+  if (pageNumber === 1) {
+    redirect("/");
+  }
+
   const allPosts = getAllPosts();
   const totalPages = getTotalPages(allPosts.length, POSTS_PER_PAGE);
+
+  // 範囲外のページ番号は404
+  if (pageNumber < 1 || pageNumber > totalPages || isNaN(pageNumber)) {
+    notFound();
+  }
   const posts = getPaginatedPosts(allPosts, pageNumber, POSTS_PER_PAGE);
 
   return (

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,5 +1,6 @@
 import { MetadataRoute } from "next";
-import { getAllPosts } from "@/lib/posts";
+import { getAllPosts, getPostsByCategory } from "@/lib/posts";
+import { getTotalPages, POSTS_PER_PAGE } from "@/lib/pagination";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = "https://blog.nexeed-web.com";
@@ -13,14 +14,50 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.8,
   }));
 
-  // カテゴリーページのURL
+  // カテゴリーページのURL（1ページ目）
   const categories = ["investment", "parenting", "engineering", "side-business", "sports", "politics"];
+  const categoryNames: Record<string, string> = {
+    "investment": "投資",
+    "parenting": "子育て",
+    "engineering": "ITエンジニア",
+    "side-business": "副業",
+    "sports": "スポーツ",
+    "politics": "政治",
+  };
   const categoryUrls = categories.map((slug) => ({
     url: `${baseUrl}/category/${slug}`,
     lastModified: new Date(),
     changeFrequency: "weekly" as const,
     priority: 0.7,
   }));
+
+  // カテゴリーページネーション（2ページ目以降）
+  const categoryPaginationUrls: MetadataRoute.Sitemap = [];
+  for (const slug of categories) {
+    const categoryName = categoryNames[slug];
+    const categoryPosts = getPostsByCategory(categoryName);
+    const totalPages = getTotalPages(categoryPosts.length, POSTS_PER_PAGE);
+    for (let i = 2; i <= totalPages; i++) {
+      categoryPaginationUrls.push({
+        url: `${baseUrl}/category/${slug}/page/${i}`,
+        lastModified: new Date(),
+        changeFrequency: "weekly" as const,
+        priority: 0.5,
+      });
+    }
+  }
+
+  // トップページネーション（2ページ目以降）
+  const totalPages = getTotalPages(posts.length, POSTS_PER_PAGE);
+  const paginationUrls: MetadataRoute.Sitemap = [];
+  for (let i = 2; i <= totalPages; i++) {
+    paginationUrls.push({
+      url: `${baseUrl}/page/${i}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: 0.5,
+    });
+  }
 
   // 静的ページのURL
   const staticPages = [
@@ -44,5 +81,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
     },
   ];
 
-  return [...staticPages, ...categoryUrls, ...postUrls];
+  return [...staticPages, ...categoryUrls, ...categoryPaginationUrls, ...paginationUrls, ...postUrls];
 }


### PR DESCRIPTION
- /page/1 へのアクセスを / にリダイレクト（重複コンテンツ防止）
- /category/[slug]/page/1 へのアクセスを /category/[slug] にリダイレクト
- 範囲外のページ番号（存在しないページ）は404を返すよう修正
- /page/[page] メタデータに alternates.canonical を追加
- sitemap.ts にトップ・カテゴリーのページネーションURL（2ページ目以降）を追加

https://claude.ai/code/session_018BWexEW9HMkY5P8hd4nfSZ